### PR TITLE
Remove heroku-rack-ssl-enforcer-rails

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,5 @@ updates:
       - dependency-name: "rake"
       - dependency-name: "rspec-*"
       - dependency-name: "pg"
-      - dependency-name: "heroku-rack-ssl-enforcer-rails"
       - dependency-name: "kaminari"
       - dependency-name: "sprockets-rails"

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ end
 
 group :production do
   gem 'pg', '~> 1.2'
-  gem 'heroku-rack-ssl-enforcer-rails'
 end
 gem 'aws-sdk-s3'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,9 +126,6 @@ GEM
       html2haml (>= 1.0.1)
       railties (>= 5.1)
     hashie (5.0.0)
-    heroku-rack-ssl-enforcer-rails (0.1.0)
-      rack-ssl-enforcer
-      railties
     html2haml (2.2.0)
       erubis (~> 2.7.0)
       haml (>= 4.0, < 6)
@@ -206,7 +203,6 @@ GEM
     rack (2.2.3)
     rack-protection (2.2.0)
       rack
-    rack-ssl-enforcer (0.2.8)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.1.4.7)
@@ -307,7 +303,6 @@ DEPENDENCIES
   aws-sdk-s3
   devise
   haml-rails
-  heroku-rack-ssl-enforcer-rails
   jbuilder (~> 2.11)
   kaminari
   omniauth-github (~> 2.0.0)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
heroku-rack-ssl-enforcer-rails is a rack-middleware to force ssl on Heroku.
`cofig.force_ssl = true` is same mean. So remove the gem.