### PR TITLE
bundle add faraday-retry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'devise'
 gem 'omniauth-github', '~> 2.0.1'
 gem 'omniauth-rails_csrf_protection', '~> 1.0.2'
 gem 'octokit', '~> 9.2'
+gem "faraday-retry", "~> 2.2"
 
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 6.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,8 @@ GEM
       logger
     faraday-net_http (3.3.0)
       net-http
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
     ffi (1.15.5)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -333,6 +335,7 @@ PLATFORMS
 DEPENDENCIES
   aws-sdk-s3
   devise
+  faraday-retry (~> 2.2)
   haml-rails
   kaminari
   octokit (~> 9.2)


### PR DESCRIPTION
To remove above warning:

> To use retry middleware with Faraday v2.0+, install `faraday-retry` gem

