### PR TITLE
Replace hash rocket syntax

### DIFF
--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -17,7 +17,7 @@ class AuthenticationController < ApplicationController
       user = User.new(name: oauth.info.name, nickname: oauth.info.nickname)
     end
     user.save
-    sign_in_and_redirect user,:event => :authentication
+    sign_in_and_redirect user, event: :authentication
   end
 
   def logout

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -14,7 +14,7 @@ class LogsController < ApplicationController
       return
     end
 
-    @log = Log.new(host: params[:host], :result => params[:log_file].read)
+    @log = Log.new(host: params[:host], result: params[:log_file].read)
     script = Script.where(guid: params[:guid]).first
     unless script
       render json: {message: "scripts not found. GUID: #{params[:guid]}"}.to_json, status: 500

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,8 +19,8 @@ module ApplicationHelper
 
       Array(message).each do |msg|
         text = content_tag(:div,
-                            content_tag(:button, raw("&times;"), :class => "close", "data-dismiss" => "alert") +
-                            msg.html_safe, :class => "alert fade in alert-#{type}")
+                            content_tag(:button, raw("&times;"), class: "close", "data-dismiss": "alert") +
+                            msg.html_safe, class: "alert fade in alert-#{type}")
         flash_messages << text if msg
       end
     end

--- a/app/views/kaminari/_first_page.html.haml
+++ b/app/views/kaminari/_first_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, :remote => remote
+  = link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote

--- a/app/views/kaminari/_last_page.html.haml
+++ b/app/views/kaminari/_last_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {:remote => remote}
+  = link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, {remote: remote}

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, :rel => 'next', :remote => remote
+  = link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -1,2 +1,2 @@
 %li
-  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, :rel => 'prev', :remote => remote
+  = link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,9 +5,9 @@
     %meta(name="viewport" content="width=device-width, initial-scale=1.0")
     %title= title(yield(:title))
     = csrf_meta_tags
-    = stylesheet_link_tag "application", :media => "all"
-    = favicon_link_tag 'apple-touch-icon.png', :rel => 'apple-touch-icon', :type => 'image/png'
-    = favicon_link_tag 'favicon.ico', :rel => 'icon'
+    = stylesheet_link_tag "application", media: "all"
+    = favicon_link_tag 'apple-touch-icon.png', rel: 'apple-touch-icon', type: 'image/png'
+    = favicon_link_tag 'favicon.ico', rel: 'icon'
     = javascript_include_tag "application"
 
   %body

--- a/app/views/scripts/_form.html.haml
+++ b/app/views/scripts/_form.html.haml
@@ -23,10 +23,10 @@
             = t(:button_remove)
 
     .fileinputs
-      = render 'form_upload', :display => 'none'
-      = render 'form_upload', :display => 'block'
+      = render 'form_upload', display: 'none'
+      = render 'form_upload', display: 'block'
     .fileinputs-more
-      = link_to '#', :class => 'attachment-more btn btn-default' do
+      = link_to '#', class: 'attachment-more btn btn-default' do
         %i.fa.fa-plus
         =t(:button_more_attachment)
 

--- a/app/views/scripts/index.html.haml
+++ b/app/views/scripts/index.html.haml
@@ -6,10 +6,10 @@
   .page-title-right-menu
     - if params[:archived] == 'true'
       = link_to scripts_path, class: 'btn btn-default active' do
-        %i.fa.fa-box-open{:title => t(:link_active_scripts)}
+        %i.fa.fa-box-open{title: t(:link_active_scripts)}
     - else
       = link_to scripts_path(archived: true), class: 'btn btn-default' do
-        %i.fa.fa-box{:title => t(:link_archived_scripts)}
+        %i.fa.fa-box{title: t(:link_archived_scripts)}
 
     = link_to t(:button_new_script), new_script_path, class: 'btn btn-default'
 

--- a/app/views/scripts/search.html.haml
+++ b/app/views/scripts/search.html.haml
@@ -6,10 +6,10 @@
   .page-title-right-menu
     - if params[:archived] == 'true'
       = link_to search_path(keyword: @keyword), class: 'btn btn-default active' do
-        %i.fa.fa-box-open{:title => t(:link_active_scripts)}
+        %i.fa.fa-box-open{title: t(:link_active_scripts)}
     - else
       = link_to search_path(keyword: @keyword, archived: true), class: 'btn btn-default' do
-        %i.fa.fa-box{:title => t(:link_archived_scripts)}
+        %i.fa.fa-box{title: t(:link_archived_scripts)}
 
 .search-box
   %form{action: search_path, method: :get}

--- a/app/views/scripts/show.html.haml
+++ b/app/views/scripts/show.html.haml
@@ -54,9 +54,9 @@
 .page-title
   %h4= t(:field_run)
   .page-title-right-menu
-    = link_to 'javascript:void(0)', :class => 'copy-button btn btn-info', :'data-clipboard-text' => "#{@script.remote_script(root_url)}", :title => t(:copy_to_clipboard), :'data-placement' => 'bottom' do
+    = link_to 'javascript:void(0)', class: 'copy-button btn btn-info', 'data-clipboard-text': "#{@script.remote_script(root_url)}", title: t(:copy_to_clipboard), 'data-placement': 'bottom' do
       %i.fa.fa-paperclip
-    = link_to 'javascript:void(0)', :class => 'copy-button btn btn-info', :'data-clipboard-text' => "#{wrapped_sh_url(@script.guid)}", :title => t(:copy_to_clipboard), :'data-placement' => 'bottom' do
+    = link_to 'javascript:void(0)', class: 'copy-button btn btn-info', 'data-clipboard-text': "#{wrapped_sh_url(@script.guid)}", title: t(:copy_to_clipboard), 'data-placement': 'bottom' do
       = t(:button_wrapped)
 
 %pre.run
@@ -89,7 +89,7 @@
           %th= t(:field_log_size)
       %tbody
       - @script.logs.select_without_result.order('created_at desc').each do |log|
-        %tr{:id => "log-#{log.id}", :class => "logs #{@highlights.include?(log.id) ? 'success' : ''}"}
+        %tr{id: "log-#{log.id}", class: "logs #{@highlights.include?(log.id) ? 'success' : ''}"}
           %td= link_to log.host, log_path(log)
           %td= log.formatted_created_at
           %td= number_to_human_size log.result_bytes


### PR DESCRIPTION
Replace the hash rocket (`=>`) syntax with the new Ruby 1.9+ hash syntax.