### PR TITLE
Avoid Could not find a valid mapping for ... error

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,4 +38,10 @@ RSpec.configure do |config|
   config.order = "random"
 
   config.include Devise::Test::ControllerHelpers, :type => :controller
+
+  # Avoid "Could not find a valid mapping for #<User...> error"
+  # It will be fixed in Devise 5
+  ActiveSupport.on_load(:action_mailer) do
+    Rails.application.reload_routes_unless_loaded
+  end
 end


### PR DESCRIPTION
`bundle exec rake spec` fails on macOS.