### PR TITLE
Remove underlines in links

### DIFF
--- a/app/assets/stylesheets/main.css.scss
+++ b/app/assets/stylesheets/main.css.scss
@@ -2,6 +2,13 @@ body {
   padding-top: 20px;
 }
 
+a:not([class*="btn"]) {
+  text-decoration: none;
+}
+a:not([class*="btn"]):hover {
+  text-decoration: underline;
+}
+
 .navbar {
   .container {
     padding-left: 0;


### PR DESCRIPTION
Bootstrap 5 has underlines in links default.
I want to remove them.