### PR TITLE
Enqueue Slack notification job after transaction commit to avoid DeserializationError

### DIFF
--- a/app/models/concerns/slack_notify.rb
+++ b/app/models/concerns/slack_notify.rb
@@ -2,7 +2,7 @@ module SlackNotify
   extend ActiveSupport::Concern
 
   included do
-    after_create :notify
+    after_create_commit :notify
   end
 
   def notify


### PR DESCRIPTION
Introduced by #646