### PR TITLE
Remove cooldown from Docker ecosystem in Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,8 +33,6 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/"
-    cooldown:
-      default-days: 3
     schedule:
       interval: "weekly"
       timezone: "Asia/Tokyo"


### PR DESCRIPTION
Docker Hub's blob API does not return Last-Modified headers, causing apply_cooldown to silently skip all candidate tags and return an empty list. This makes Dependabot treat the current version as the latest, preventing version update PRs from being created.