### PR TITLE
Allow multiple GitHub organizations in OMNIAUTH_GITHUB_ORGANIZATION

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ export SECRET_KEY_BASE=$(bin/rails secret)
 $ export DEVISE_SECRET_KEY=$(bin/rails secret)
 $ export OMNIAUTH_GITHUB_CLIENT_ID=Client ID
 $ export OMNIAUTH_GITHUB_CLIENT_SECRET=Client Secret
-$ export OMNIAUTH_GITHUB_ORGANIZATION=Some Organization # optional
+$ export OMNIAUTH_GITHUB_ORGANIZATION="org1 org2" # optional, space-separated for multiple orgs
 $ bin/rails s -e production
 ```
 

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -32,9 +32,10 @@ class AuthenticationController < Devise::OmniauthCallbacksController
   private
 
   def organization_member?(oauth)
-    return true if Settings.omniauth.github.organization.blank?
+    organizations = Settings.omniauth.github.organization.split
+    return true if organizations.empty?
 
     client = Octokit::Client.new(access_token: oauth.credentials.token)
-    client.organization_member?(Settings.omniauth.github.organization, oauth.info.nickname)
+    organizations.any? { |org| client.organization_member?(org, oauth.info.nickname) }
   end
 end


### PR DESCRIPTION
Support space-separated org names so users belonging to any one of the specified organizations are permitted to log in.