### PR TITLE
Add scheduled workflow to delete buildkit cache before Dependabot runs

### DIFF
--- a/.github/workflows/delete-buildkit-cache.yml
+++ b/.github/workflows/delete-buildkit-cache.yml
@@ -1,0 +1,20 @@
+name: Delete buildkit cache
+
+on:
+  schedule:
+    - cron: '0 14 * * 5' # JST Fri 23:00
+  workflow_dispatch: {}
+
+permissions: {}
+
+jobs:
+  delete-buildkit-cache:
+    permissions:
+      actions: write
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Delete buildkit blob cache
+        uses: suer/gh-delete-actions-caches@514affb4860b0ddce45688976680ad6281a8eca0 # v0.0.4
+        with:
+          key-prefix: buildkit-blob-1-


### PR DESCRIPTION
Dependabot's weekly docker PRs bump base image versions, but the trivy scan in CI reuses the week-old buildx GHA cache, so the apt upgrade in Dockerfile is skipped and stale, vulnerable packages get scanned, failing trivy. Purge the buildkit-blob-1- cache every Friday night so Dependabot's build starts from a clean cache.